### PR TITLE
Fix dark mode toggle

### DIFF
--- a/css/darkModeToggle.css
+++ b/css/darkModeToggle.css
@@ -1,0 +1,135 @@
+
+
+
+/* Header-specific positioning */
+.app-header #dark-mode-toggle-container {
+    position: absolute;
+    top: 50%;
+    right: 60px; /* Position it left of the settings button */
+    transform: translateY(-50%);
+}
+
+/* Alternative: Add to header controls */
+.header-controls #dark-mode-toggle-container {
+    position: relative;
+    top: auto;
+    right: auto;
+    transform: none;
+}
+
+/* Remove fixed positioning when inside header */
+.app-header .dark-mode-toggle-container {
+    position: relative;
+    top: auto;
+    right: auto;
+    z-index: auto;
+}
+
+
+/* Dark Mode Toggle Styles */
+.dark-mode-toggle-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1000;
+}
+
+.dark-mode-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg-secondary, #f5f5f5);
+    border: 2px solid var(--border-color, #e0e0e0);
+    border-radius: 25px;
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 16px;
+    outline: none;
+}
+
+.dark-mode-toggle:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.dark-mode-toggle:focus {
+    outline: 2px solid var(--accent-color, #007bff);
+    outline-offset: 2px;
+}
+
+.toggle-track {
+    width: 40px;
+    height: 20px;
+    background: #ccc;
+    border-radius: 10px;
+    position: relative;
+    transition: background-color 0.3s ease;
+}
+
+.toggle-thumb {
+    width: 16px;
+    height: 16px;
+    background: white;
+    border-radius: 50%;
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.3s ease;
+}
+
+.dark-mode-toggle.active .toggle-track {
+    background: var(--accent-color, #007bff);
+}
+
+.dark-mode-toggle.active .toggle-thumb {
+    transform: translateX(20px);
+}
+
+.sun-icon, .moon-icon {
+    font-size: 18px;
+    transition: opacity 0.3s ease;
+}
+
+.dark-mode-toggle.active .sun-icon {
+    opacity: 0.5;
+}
+
+.dark-mode-toggle:not(.active) .moon-icon {
+    opacity: 0.5;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: var(--bg-primary, #1a1a1a);
+    color: var(--text-primary, #ffffff);
+}
+
+.dark-mode .card {
+    background-color: var(--bg-secondary, #2d2d2d);
+    border-color: var(--border-color, #404040);
+}
+
+.dark-mode .btn {
+    background-color: var(--bg-secondary, #2d2d2d);
+    color: var(--text-primary, #ffffff);
+    border-color: var(--border-color, #404040);
+}
+
+.dark-mode .btn:hover {
+    background-color: var(--accent-color, #4a9eff);
+}
+
+/* Screen reader only text */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+

--- a/js/modules/ui/darkModeToggle.js
+++ b/js/modules/ui/darkModeToggle.js
@@ -174,15 +174,17 @@ addToHeader(toggleContainer) {
     applyMode() {
         const body = document.body;
         const html = document.documentElement;
-        
+
         if (this.isDarkMode) {
             body.classList.add('dark-mode');
             html.classList.add('dark-mode');
             body.setAttribute('data-theme', 'dark');
+            html.setAttribute('data-theme', 'dark');
         } else {
             body.classList.remove('dark-mode');
             html.classList.remove('dark-mode');
             body.setAttribute('data-theme', 'light');
+            html.setAttribute('data-theme', 'light');
         }
         
         // Update CSS custom properties


### PR DESCRIPTION
## Summary
- fix data-theme attribute updates when toggling dark mode
- add missing CSS styles for the dark mode toggle button

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6842d7bb3a30832bb922a81a87545905