### PR TITLE
Fix dark mode override for themes

### DIFF
--- a/js/modules/ui/darkModeToggle.js
+++ b/js/modules/ui/darkModeToggle.js
@@ -173,18 +173,13 @@ addToHeader(toggleContainer) {
     
     applyMode() {
         const body = document.body;
-        const html = document.documentElement;
 
         if (this.isDarkMode) {
             body.classList.add('dark-mode');
-            html.classList.add('dark-mode');
             body.setAttribute('data-theme', 'dark');
-            html.setAttribute('data-theme', 'dark');
         } else {
             body.classList.remove('dark-mode');
-            html.classList.remove('dark-mode');
             body.setAttribute('data-theme', 'light');
-            html.setAttribute('data-theme', 'light');
         }
         
         // Update CSS custom properties


### PR DESCRIPTION
## Summary
- ensure dark mode toggle doesn't overwrite selected theme

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: 403 Forbidden downloading jest)*

------
https://chatgpt.com/codex/tasks/task_e_6843022b178c832b8ce106a2bd5887d3