### PR TITLE
Add Jetsons cartoon theme

### DIFF
--- a/components/settings-screen.html
+++ b/components/settings-screen.html
@@ -38,6 +38,11 @@
                             <option value="space-galaxy" data-i18n="themes.spaceGalaxy">🚀 Space Galaxy</option>
                             <option value="candy-pop" data-i18n="themes.candyPop">🍭 Candy Pop</option>
                         </optgroup>
+
+                        <!-- Cartoon Themes -->
+                        <optgroup label="Cartoon Themes">
+                            <option value="jetsons" data-i18n="themes.jetsons">🤖 Jetsons</option>
+                        </optgroup>
                     </select>
                 </div>
 

--- a/css/themes/cartoon-jetsons.css
+++ b/css/themes/cartoon-jetsons.css
@@ -1,0 +1,27 @@
+/**
+ * File: css/themes/cartoon-jetsons.css
+ * LingoQuest - Jetsons Cartoon Theme
+ * Futuristic cartoon style with retro vibes
+ */
+
+[data-theme="jetsons"] {
+  --primary-color: #5bc0de;
+  --secondary-color: #f0ad4e;
+  --accent-color: #ffce00;
+  --background-color: #e0f7fa;
+  --surface-color: #ffffff;
+  --card-background: #f8f9fa;
+
+  --text-primary: #2c3e50;
+  --text-secondary: #34495e;
+  --text-accent: #ff5722;
+  --text-muted: #657786;
+
+  --button-primary-bg: linear-gradient(45deg, #5bc0de, #f0ad4e);
+  --button-primary-hover: linear-gradient(45deg, #f0ad4e, #5bc0de);
+  --button-secondary-bg: #ffffff;
+  --button-secondary-border: 2px solid #5bc0de;
+
+  --border-radius: 10px;
+  --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}

--- a/js/data/config/adminConfig.js
+++ b/js/data/config/adminConfig.js
@@ -103,6 +103,10 @@ export const adminConfig = {
             studentThemes: {
                 enabled: true,
                 themes: ['neon-glow', 'retro-arcade', 'nature-forest', 'space-galaxy', 'candy-pop']
+            },
+            cartoonThemes: {
+                enabled: true,
+                themes: ['jetsons']
             }
         },
         

--- a/js/data/config/constants.js
+++ b/js/data/config/constants.js
@@ -102,7 +102,8 @@ export const THEMES = {
     RETRO_ARCADE: 'retro-arcade',
     NATURE_FOREST: 'nature-forest',
     SPACE_GALAXY: 'space-galaxy',
-    CANDY_POP: 'candy-pop'
+    CANDY_POP: 'candy-pop',
+    JETSONS: 'jetsons'
 };
 
 // Language codes (ISO 639-1)

--- a/js/data/themes/themes.js
+++ b/js/data/themes/themes.js
@@ -208,6 +208,34 @@ const themes = {
       ageGroup: '6-18',
       popularity: 'medium'
     }
+  },
+
+  // Cartoon themes for a fun retro vibe
+  cartoon: {
+    jetsons: {
+      id: 'jetsons',
+      name: 'Jetsons',
+      category: 'cartoon',
+      description: 'Futuristic cartoon style inspired by the classic show',
+      cssFile: 'css/themes/cartoon-jetsons.css',
+      accessibility: {
+        highContrast: false,
+        largeText: false,
+        reducedMotion: false,
+        animations: true
+      },
+      colors: {
+        primary: '#5bc0de',
+        secondary: '#f0ad4e',
+        background: '#e0f7fa',
+        text: '#2c3e50'
+      },
+      features: ['retro-future', 'cartoon-style', 'fun-animations'],
+      mood: 'playful',
+      ageGroup: '6-18',
+      popularity: 'medium',
+      studyFriendly: false
+    }
   }
 };
 
@@ -226,6 +254,13 @@ const categories = {
     targetAge: '6-18',
     focus: 'engagement',
     features: ['animations', 'modern-design', 'interactive-effects', 'vibrant-colors']
+  },
+  cartoon: {
+    name: 'Cartoon Themes',
+    description: 'Themes inspired by classic cartoons',
+    targetAge: '6-18',
+    focus: 'fun',
+    features: ['bright-colors', 'whimsical-style', 'nostalgic']
   }
 };
 
@@ -239,12 +274,17 @@ export function getThemeConfig(themeId) {
   if (themes.senior[themeId]) {
     return themes.senior[themeId];
   }
-  
+
   // Search in student themes
   if (themes.student[themeId]) {
     return themes.student[themeId];
   }
-  
+
+  // Search in cartoon themes
+  if (themes.cartoon[themeId]) {
+    return themes.cartoon[themeId];
+  }
+
   return null;
 }
 
@@ -276,6 +316,12 @@ export function getThemesByAgeGroup(ageGroup) {
       suitableThemes.push(theme);
     }
   });
+
+  Object.values(themes.cartoon).forEach(theme => {
+    if (theme.ageGroup === ageGroup) {
+      suitableThemes.push(theme);
+    }
+  });
   
   return suitableThemes;
 }
@@ -288,7 +334,7 @@ export function getThemesByAgeGroup(ageGroup) {
 export function getRecommendedThemes(category = null) {
   const recommended = [];
   
-  const searchCategories = category ? [category] : ['senior', 'student'];
+  const searchCategories = category ? [category] : ['senior', 'student', 'cartoon'];
   
   searchCategories.forEach(cat => {
     Object.values(themes[cat]).forEach(theme => {
@@ -342,13 +388,19 @@ export function supportsAccessibilityFeature(themeId, feature) {
  */
 export function getThemesByMood(mood) {
   const moodThemes = [];
-  
+
   Object.values(themes.student).forEach(theme => {
     if (theme.mood === mood) {
       moodThemes.push(theme);
     }
   });
-  
+
+  Object.values(themes.cartoon).forEach(theme => {
+    if (theme.mood === mood) {
+      moodThemes.push(theme);
+    }
+  });
+
   return moodThemes;
 }
 
@@ -366,6 +418,13 @@ export function getStudyFriendlyThemes() {
   
   // Student themes marked as study-friendly
   Object.values(themes.student).forEach(theme => {
+    if (theme.studyFriendly) {
+      studyThemes.push(theme);
+    }
+  });
+
+  // Cartoon themes marked as study-friendly
+  Object.values(themes.cartoon).forEach(theme => {
     if (theme.studyFriendly) {
       studyThemes.push(theme);
     }

--- a/js/data/translations/en.js
+++ b/js/data/translations/en.js
@@ -235,7 +235,8 @@ const englishTranslations = {
       retroArcade: 'Retro Arcade',
       natureForest: 'Nature Forest',
       spaceGalaxy: 'Space Galaxy',
-      candyPop: 'Candy Pop'
+      candyPop: 'Candy Pop',
+      jetsons: 'Jetsons'
     },
     
     // Font Settings

--- a/js/data/translations/fr.js
+++ b/js/data/translations/fr.js
@@ -108,7 +108,8 @@ export const frTranslations = {
         retroArcade: 'Arcade rétro',
         natureForest: 'Forêt naturelle',
         spaceGalaxy: 'Galaxie spatiale',
-        candyPop: 'Bonbons pop'
+        candyPop: 'Bonbons pop',
+        jetsons: 'Jetsons'
     },
     
     // User profiles

--- a/js/modules/settings/themeManager.js
+++ b/js/modules/settings/themeManager.js
@@ -23,14 +23,18 @@ class ThemeManager {
         
         // Student themes (separate CSS files)
         this.studentThemes = ['neon-glow', 'retro-arcade', 'nature-forest', 'space-galaxy', 'candy-pop'];
-        
+
+        // Cartoon themes (separate CSS files)
+        this.cartoonThemes = ['jetsons'];
+
         // All available themes
-        this.themes = [...this.seniorThemes, ...this.studentThemes];
+        this.themes = [...this.seniorThemes, ...this.studentThemes, ...this.cartoonThemes];
         
         // Theme categories for UI organization
         this.themeCategories = {
             senior: this.seniorThemes,
-            student: this.studentThemes
+            student: this.studentThemes,
+            cartoon: this.cartoonThemes
         };
         
         // CSS file mappings for student themes
@@ -39,7 +43,8 @@ class ThemeManager {
             'retro-arcade': 'css/themes/student-retro-arcade.css',
             'nature-forest': 'css/themes/student-nature-forest.css',
             'space-galaxy': 'css/themes/student-space-galaxy.css',
-            'candy-pop': 'css/themes/student-candy-pop.css'
+            'candy-pop': 'css/themes/student-candy-pop.css',
+            'jetsons': 'css/themes/cartoon-jetsons.css'
         };
         
         this.loadedThemeFiles = new Set();
@@ -67,8 +72,8 @@ class ThemeManager {
             themeName = 'light';
         }
         
-        // Load CSS file for student themes
-        if (this.studentThemes.includes(themeName)) {
+        // Load CSS file for student or cartoon themes
+        if (this.studentThemes.includes(themeName) || this.cartoonThemes.includes(themeName)) {
             await this.loadStudentThemeCSS(themeName);
         }
         
@@ -135,6 +140,7 @@ class ThemeManager {
     getThemeCategory(themeName) {
         if (this.seniorThemes.includes(themeName)) return 'senior';
         if (this.studentThemes.includes(themeName)) return 'student';
+        if (this.cartoonThemes.includes(themeName)) return 'cartoon';
         return 'unknown';
     }
     
@@ -171,7 +177,8 @@ class ThemeManager {
             'retro-arcade': 'Retro Arcade',
             'nature-forest': 'Nature Forest',
             'space-galaxy': 'Space Galaxy',
-            'candy-pop': 'Candy Pop'
+            'candy-pop': 'Candy Pop',
+            'jetsons': 'Jetsons'
         };
         return displayNames[themeName] || themeName;
     }


### PR DESCRIPTION
## Summary
- add new `cartoon` theme category with Jetsons theme
- load Jetsons CSS in theme manager and settings screen
- translate Jetsons theme name in English and French
- update constants and admin config
- include Jetsons theme styles

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68431e504b44832b8723f640176c1400