### PR TITLE
Fix translation keys for button labels

### DIFF
--- a/js/data/translations/en.js
+++ b/js/data/translations/en.js
@@ -48,6 +48,29 @@ const englishTranslations = {
     logout: 'Logout'
   },
 
+  // ===== BUTTON LABELS =====
+  buttons: {
+    start: 'Start Game',
+    startHollyBolly: 'Start HollyBolly',
+    howToPlay: 'How to Play',
+    confirm: 'Confirm Answer',
+    continue: 'Continue Game',
+    pause: 'Pause',
+    quit: 'Quit Game',
+    viewDetails: 'View Detailed Results',
+    playAgain: 'Play Again',
+    tryDifferentMode: 'Try Different Mode',
+    home: 'Home',
+    share: 'Share Results',
+    exportData: 'Export My Data',
+    resetData: 'Reset All Data',
+    checkUpdates: 'Check for Updates',
+    privacyPolicy: 'Privacy Policy',
+    termsService: 'Terms of Service',
+    startTutorial: 'Start Tutorial',
+    gotIt: 'Got It!'
+  },
+
   // ===== HOME SCREEN =====
   home: {
     welcome: 'Welcome to LingoQuest',

--- a/js/data/translations/fr.js
+++ b/js/data/translations/fr.js
@@ -44,6 +44,29 @@ export const frTranslations = {
         submit: 'Soumettre',
         reset: 'Réinitialiser'
     },
+
+    // Libellés des boutons
+    buttons: {
+        start: 'Commencer le jeu',
+        startHollyBolly: 'Commencer HollyBolly',
+        howToPlay: 'Comment jouer',
+        confirm: 'Confirmer la réponse',
+        continue: 'Continuer le jeu',
+        pause: 'Pause',
+        quit: 'Quitter le jeu',
+        viewDetails: 'Voir les résultats détaillés',
+        playAgain: 'Rejouer',
+        tryDifferentMode: 'Essayer un autre mode',
+        home: 'Accueil',
+        share: 'Partager les résultats',
+        exportData: 'Exporter mes données',
+        resetData: 'Réinitialiser toutes les données',
+        checkUpdates: 'Vérifier les mises à jour',
+        privacyPolicy: 'Politique de confidentialité',
+        termsService: "Conditions d'utilisation",
+        startTutorial: 'Commencer le tutoriel',
+        gotIt: 'Compris!'
+    },
     
     // Game modes
     modes: {


### PR DESCRIPTION
## Summary
- add missing `buttons` translations in English and French

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684323100efc832b94e6b80c6d4ccd9d