### PR TITLE
Fix theme summary to include cartoon category

### DIFF
--- a/components/settings-screen.html
+++ b/components/settings-screen.html
@@ -277,7 +277,7 @@
 
                 <div class="setting-item info-item">
                     <span data-i18n="settings.themesAvailable">Themes Available:</span>
-                    <span class="info-value">11 Total (6 Senior + 5 Student)</span>
+                    <span class="info-value">12 Total (6 Senior + 5 Student + 1 Cartoon)</span>
                 </div>
 
                 <div class="setting-item">


### PR DESCRIPTION
## Summary
- update theme summary to count the new Cartoon category

## Testing
- `npm test` *(fails: 403 Forbidden when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_6843253b981c832b9b302c0713f6f2c1