### PR TITLE
Add tools screen with reset functions

### DIFF
--- a/components/settings-screen.html
+++ b/components/settings-screen.html
@@ -297,6 +297,11 @@
                         <span data-i18n="buttons.termsService">Terms of Service</span>
                     </button>
                 </div>
+                <div class="setting-item">
+                    <button id="open-tools" class="btn btn-outline">
+                        Tools
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/components/tools-screen.html
+++ b/components/tools-screen.html
@@ -1,0 +1,27 @@
+<!-- Tools Screen -->
+<section id="tools-screen" class="screen">
+    <div class="screen-content">
+        <div class="tools-header">
+            <button id="close-tools" class="btn btn-icon" aria-label="Close Tools">
+                <svg class="icon" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"/>
+                </svg>
+            </button>
+            <h2 class="screen-title">Tools</h2>
+        </div>
+        <div class="tools-content">
+            <div class="setting-group">
+                <div class="setting-item">
+                    <button id="reset-service-worker" class="btn btn-outline btn-danger">
+                        Reset Service Worker
+                    </button>
+                </div>
+                <div class="setting-item">
+                    <button id="reset-cache" class="btn btn-outline btn-danger">
+                        Reset Cache
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             <div id="results-screen-container"></div>
             <div id="settings-screen-container"></div>
             <div id="instructions-screen-container"></div>
+            <div id="tools-screen-container"></div>
         </main>
 
         <div id="loading-overlay-container"></div>

--- a/js/modules/core/componentLoader.js
+++ b/js/modules/core/componentLoader.js
@@ -58,6 +58,7 @@ class ComponentLoader {
             { name: 'results-screen', containerId: 'results-screen-container' },
             { name: 'settings-screen', containerId: 'settings-screen-container' },
             { name: 'instructions-screen', containerId: 'instructions-screen-container' },
+            { name: 'tools-screen', containerId: 'tools-screen-container' },
             { name: 'loading-overlay', containerId: 'loading-overlay-container' },
             { name: 'toast-container', containerId: 'toast-container-element' }
         ];

--- a/js/modules/core/eventManager.js
+++ b/js/modules/core/eventManager.js
@@ -10,6 +10,7 @@ class EventManager {
         this.setupHomeScreenEvents();
         this.setupGameScreenEvents();
         this.setupSettingsScreenEvents();
+        this.setupToolsScreenEvents();
         this.setupGlobalEvents();
     }
 
@@ -66,11 +67,31 @@ class EventManager {
         });
     }
 
+    setupToolsScreenEvents() {
+        document.addEventListener('click', async (e) => {
+            if (e.target.closest('#open-tools')) {
+                this.app.getUIManager().showScreen('tools-screen');
+            }
+
+            if (e.target.closest('#close-tools')) {
+                this.app.getUIManager().showScreen('settings-screen');
+            }
+
+            if (e.target.closest('#reset-service-worker')) {
+                await this.resetServiceWorker();
+            }
+
+            if (e.target.closest('#reset-cache')) {
+                await this.resetCache();
+            }
+        });
+    }
+
     setupGlobalEvents() {
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
                 const currentScreen = this.app.getUIManager().currentScreen;
-                if (currentScreen === 'settings-screen' || currentScreen === 'instructions-screen') {
+                if (currentScreen === 'settings-screen' || currentScreen === 'instructions-screen' || currentScreen === 'tools-screen') {
                     this.app.getUIManager().showScreen('home-screen');
                 }
             }
@@ -90,6 +111,26 @@ class EventManager {
             const name = this.app.getThemeManager().getThemeDisplayName(theme);
             this.app.getUIManager().showToast(`Theme changed to ${name}`, 'success');
         });
+    }
+
+    async resetServiceWorker() {
+        if ('serviceWorker' in navigator) {
+            const registrations = await navigator.serviceWorker.getRegistrations();
+            for (const reg of registrations) {
+                await reg.unregister();
+            }
+            this.app.getUIManager().showToast('Service worker reset', 'success');
+            setTimeout(() => location.reload(true), 500);
+        }
+    }
+
+    async resetCache() {
+        if ('caches' in window) {
+            const names = await caches.keys();
+            await Promise.all(names.map(name => name.startsWith('lingoquest-') ? caches.delete(name) : null));
+            this.app.getUIManager().showToast('Cache cleared', 'success');
+            setTimeout(() => location.reload(true), 500);
+        }
     }
 
     switchGameModeTab(gameMode) {


### PR DESCRIPTION
## Summary
- add new Tools screen component
- load tools screen in index and component loader
- link Tools from Settings
- handle Tools screen events in EventManager
- allow resetting service worker and caches

## Testing
- `npm test` *(fails: 403 Forbidden when trying to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684327b6e4f4832b89856c24827dd651