### PR TITLE
Add mobile script blocker detection

### DIFF
--- a/js/blocker-test.js
+++ b/js/blocker-test.js
@@ -1,0 +1,1 @@
+window.scriptBlockerLoaded = true;


### PR DESCRIPTION
## Summary
- alert users about mobile script blockers that interfere with themes

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684329bd88c4832b811bfd72f0203515