### PR TITLE
Add reset delay selector

### DIFF
--- a/components/tools-screen.html
+++ b/components/tools-screen.html
@@ -12,6 +12,14 @@
         <div class="tools-content">
             <div class="setting-group">
                 <div class="setting-item">
+                    <label for="reset-delay-select">Reset After</label>
+                    <select id="reset-delay-select" class="select">
+                        <option value="60000">1 min</option>
+                        <option value="180000">3 min</option>
+                        <option value="300000">5 min</option>
+                    </select>
+                </div>
+                <div class="setting-item">
                     <button id="reset-service-worker" class="btn btn-outline btn-danger">
                         Reset Service Worker
                     </button>

--- a/js/modules/core/eventManager.js
+++ b/js/modules/core/eventManager.js
@@ -114,23 +114,48 @@ class EventManager {
     }
 
     async resetServiceWorker() {
-        if ('serviceWorker' in navigator) {
-            const registrations = await navigator.serviceWorker.getRegistrations();
-            for (const reg of registrations) {
-                await reg.unregister();
+        const delay = this.getResetDelay();
+        const performReset = async () => {
+            if ('serviceWorker' in navigator) {
+                const registrations = await navigator.serviceWorker.getRegistrations();
+                for (const reg of registrations) {
+                    await reg.unregister();
+                }
+                this.app.getUIManager().showToast('Service worker reset', 'success');
+                setTimeout(() => location.reload(true), 500);
             }
-            this.app.getUIManager().showToast('Service worker reset', 'success');
-            setTimeout(() => location.reload(true), 500);
+        };
+
+        if (delay > 0) {
+            this.app.getUIManager().showToast(`Service worker will reset in ${delay / 60000} min`, 'info');
+            setTimeout(performReset, delay);
+        } else {
+            await performReset();
         }
     }
 
     async resetCache() {
-        if ('caches' in window) {
-            const names = await caches.keys();
-            await Promise.all(names.map(name => name.startsWith('lingoquest-') ? caches.delete(name) : null));
-            this.app.getUIManager().showToast('Cache cleared', 'success');
-            setTimeout(() => location.reload(true), 500);
+        const delay = this.getResetDelay();
+        const performReset = async () => {
+            if ('caches' in window) {
+                const names = await caches.keys();
+                await Promise.all(names.map(name => name.startsWith('lingoquest-') ? caches.delete(name) : null));
+                this.app.getUIManager().showToast('Cache cleared', 'success');
+                setTimeout(() => location.reload(true), 500);
+            }
+        };
+
+        if (delay > 0) {
+            this.app.getUIManager().showToast(`Cache will reset in ${delay / 60000} min`, 'info');
+            setTimeout(performReset, delay);
+        } else {
+            await performReset();
         }
+    }
+
+    getResetDelay() {
+        const select = document.getElementById('reset-delay-select');
+        return select ? parseInt(select.value, 10) || 0 : 0;
     }
 
     switchGameModeTab(gameMode) {


### PR DESCRIPTION
## Summary
- add delay dropdown to Tools screen
- allow resetting service worker or cache after selected delay

## Testing
- `npm test` *(fails: 403 Forbidden for jest)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run lint:css` *(fails: 403 Forbidden for stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68432c3ae254832b99e94b407f1a2e72