### PR TITLE
Fix settings page caching issue

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 
 // LingoQuest Service Worker
 // Bump cache versions whenever assets change to force refresh
-const CACHE_NAME = 'lingoquest-v1.0.1';
-const STATIC_CACHE_NAME = 'lingoquest-static-v1.0.1';
-const DYNAMIC_CACHE_NAME = 'lingoquest-dynamic-v1.0.1';
+const CACHE_NAME = 'lingoquest-v1.0.2';
+const STATIC_CACHE_NAME = 'lingoquest-static-v1.0.2';
+const DYNAMIC_CACHE_NAME = 'lingoquest-dynamic-v1.0.2';
 
 // Files to cache for offline functionality
 const STATIC_ASSETS = [


### PR DESCRIPTION
## Summary
- bump service worker cache version to ensure Safari loads latest settings page

## Testing
- `npm test` *(fails: 403 Forbidden while fetching jest)*

------
https://chatgpt.com/codex/tasks/task_e_6843330d8ec8832b88edf51b363c46ae