### PR TITLE
Fix classic mode data

### DIFF
--- a/js/modules/game/mcqGenerator.js
+++ b/js/modules/game/mcqGenerator.js
@@ -1,4 +1,10 @@
 
+import { arrayUtils } from '../utils/helpers.js';
+import { animalsData } from '../../data/questions/classic/animals.js';
+import { placesData } from '../../data/questions/classic/places.js';
+import { thingsData } from '../../data/questions/classic/things.js';
+import { NAMES_DATABASE } from '../../data/questions/classic/names.js';
+
 class MCQGenerator {
     constructor() {
         this.categories = ['name', 'place', 'animal', 'thing'];
@@ -33,14 +39,56 @@ class MCQGenerator {
     }
 
     generateClassicQuestion(choiceCount, category, letter) {
-        const choices = this.generateChoices(choiceCount, category, letter);
+        let questionText = `Choose a ${category.toUpperCase()} that starts with "${letter}"`;
+        let answers = [];
+        let correctAnswer = null;
+
+        if (category === 'name') {
+            const letterData = NAMES_DATABASE[letter] || { easy: [] };
+            const correctPool = letterData.easy || [];
+            const otherNames = [];
+            for (const [ltr, data] of Object.entries(NAMES_DATABASE)) {
+                if (ltr !== letter && data.easy) {
+                    otherNames.push(...data.easy.map(n => n.name));
+                }
+            }
+
+            if (correctPool.length > 0) {
+                correctAnswer = arrayUtils.randomElement(correctPool).name;
+            } else {
+                correctAnswer = arrayUtils.randomElement(otherNames) || '';
+            }
+
+            const wrongChoices = arrayUtils.randomElements(otherNames, choiceCount - 1);
+            answers = [correctAnswer, ...wrongChoices];
+        } else {
+            const dataMap = { place: placesData, animal: animalsData, thing: thingsData };
+            const dataset = dataMap[category];
+            if (dataset && dataset.questions) {
+                const pool = dataset.questions.filter(q => q.letter === letter);
+                const selected = pool.length > 0 ? arrayUtils.randomElement(pool) : arrayUtils.randomElement(dataset.questions);
+                questionText = selected.question;
+                correctAnswer = selected.correctAnswer;
+                const incorrect = selected.options.filter(o => o !== correctAnswer);
+                const wrongChoices = arrayUtils.randomElements(incorrect, choiceCount - 1);
+                answers = [correctAnswer, ...wrongChoices];
+            }
+        }
+
+        answers = arrayUtils.shuffle(answers).slice(0, choiceCount);
+
+        const choices = answers.map(choice => ({
+            text: choice,
+            correct: choice === correctAnswer,
+            explanation: choice === correctAnswer ? 'Correct!' : 'Try again!'
+        }));
 
         return {
             type: 'classic',
-            category: category,
-            letter: letter,
-            text: `Choose a ${category.toUpperCase()} that starts with "${letter}"`,
-            choices: choices
+            category,
+            letter,
+            text: questionText,
+            choices
         };
     }
 
@@ -65,21 +113,9 @@ class MCQGenerator {
         };
     }
 
-    generateChoices(choiceCount, category, letter) {
-        // Mock choices for demo
-        const mockChoices = {
-            name: ['Alice', 'Bob', 'Charlie', 'David'],
-            place: ['Australia', 'Brazil', 'Canada', 'Denmark'],
-            animal: ['Ant', 'Bear', 'Cat', 'Dog'],
-            thing: ['Apple', 'Book', 'Car', 'Door']
-        };
-
-        const categoryChoices = mockChoices[category] || mockChoices.name;
-        return categoryChoices.slice(0, choiceCount).map((choice, index) => ({
-            text: choice,
-            correct: index === 0,
-            explanation: index === 0 ? 'Correct!' : 'Try again!'
-        }));
+    // Deprecated mock choice generator retained for backward compatibility
+    generateChoices() {
+        return [];
     }
 
     getChoiceCount(mode) {


### PR DESCRIPTION
## Summary
- pull questions for classic mode from data files instead of placeholders

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: 403 Forbidden when downloading jest)*

------
https://chatgpt.com/codex/tasks/task_e_684335d595e0832b9e46d046d7d72a1f