### PR TITLE
Add MixLingo game mode

### DIFF
--- a/GameUI.js
+++ b/GameUI.js
@@ -1,12 +1,13 @@
 
 import { HollyBollyGame } from './HollyBollyGame.js';
+import { MixLingoGame } from './mixlingo.js';
 
 /**
  * GameUI - Handles all user interface interactions and game display
  */
 export class GameUI {
-    constructor() {
-        this.game = new HollyBollyGame();
+    constructor(gameType = 'hollybolly') {
+        this.game = gameType === 'mixlingo' ? new MixLingoGame() : new HollyBollyGame();
         this.currentQuestion = null;
         this.isAnswered = false;
         

--- a/components/home-screen.html
+++ b/components/home-screen.html
@@ -17,6 +17,9 @@
             <div class="mode-tab" data-game-mode="hollybolly">
                 <span data-i18n="gameModes.hollybolly">HollyBolly Mode</span>
             </div>
+            <div class="mode-tab" data-game-mode="mixlingo">
+                <span data-i18n="gameModes.mixlingo">MixLingo Mode</span>
+            </div>
         </div>
 
         <!-- Classic Game Modes -->
@@ -88,6 +91,33 @@
                 <p data-i18n="hollybolly.hard.description">4 movie choices + rewards</p>
                 <button class="btn btn-primary btn-large" data-action="start-game" data-mode="hard" data-game-type="hollybolly">
                     <span data-i18n="buttons.startHollyBolly">Start HollyBolly</span>
+                </button>
+            </div>
+        </div>
+
+        <!-- MixLingo Game Modes -->
+        <div id="mixlingo-modes" class="game-modes">
+            <div class="mode-card" data-mode="easy" data-game-type="mixlingo">
+                <h3 data-i18n="modes.easy.title">Easy Mode</h3>
+                <p data-i18n="modes.easy.description">2 choices per question</p>
+                <button class="btn btn-primary btn-large" data-action="start-game" data-mode="easy" data-game-type="mixlingo">
+                    <span data-i18n="buttons.start">Start Game</span>
+                </button>
+            </div>
+
+            <div class="mode-card" data-mode="medium" data-game-type="mixlingo">
+                <h3 data-i18n="modes.medium.title">Medium Mode</h3>
+                <p data-i18n="modes.medium.description">3 choices per question</p>
+                <button class="btn btn-primary btn-large" data-action="start-game" data-mode="medium" data-game-type="mixlingo">
+                    <span data-i18n="buttons.start">Start Game</span>
+                </button>
+            </div>
+
+            <div class="mode-card" data-mode="hard" data-game-type="mixlingo">
+                <h3 data-i18n="modes.hard.title">Hard Mode</h3>
+                <p data-i18n="modes.hard.description">4 choices per question</p>
+                <button class="btn btn-primary btn-large" data-action="start-game" data-mode="hard" data-game-type="mixlingo">
+                    <span data-i18n="buttons.start">Start Game</span>
                 </button>
             </div>
         </div>

--- a/components/instructions-screen.html
+++ b/components/instructions-screen.html
@@ -21,6 +21,9 @@
                 <button class="instruction-tab" data-tab="hollybolly">
                     <span data-i18n="gameModes.hollybolly">HollyBolly Mode</span>
                 </button>
+                <button class="instruction-tab" data-tab="mixlingo">
+                    <span data-i18n="gameModes.mixlingo">MixLingo Mode</span>
+                </button>
             </div>
 
             <!-- Classic Mode Instructions -->
@@ -214,6 +217,33 @@
                         <div class="tip-item">
                             <span class="tip-icon">🔄</span>
                             <p data-i18n="hollybolly.tip3">Keep your streak going to unlock more valuable rewards!</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- MixLingo Mode Instructions -->
+            <div id="mixlingo-instructions" class="instruction-content">
+                <div class="instruction-section">
+                    <h3 data-i18n="mixlingo.objective">📝 MixLingo Challenge</h3>
+                    <p data-i18n="mixlingo.objectiveText">Choose the correct foreign word to complete each English sentence.</p>
+                </div>
+
+                <div class="instruction-section">
+                    <h3 data-i18n="mixlingo.howItWorks">🌍 How It Works</h3>
+                    <p data-i18n="mixlingo.howItWorksText">One word in the sentence is replaced with options from the selected language. Pick the word that fits best.</p>
+                </div>
+
+                <div class="instruction-section">
+                    <h3 data-i18n="mixlingo.tips">💡 Tips for Success</h3>
+                    <div class="tips-list">
+                        <div class="tip-item">
+                            <span class="tip-icon">📖</span>
+                            <p data-i18n="mixlingo.tip1">Read the whole sentence before choosing.</p>
+                        </div>
+                        <div class="tip-item">
+                            <span class="tip-icon">🔊</span>
+                            <p data-i18n="mixlingo.tip2">Say the sentence out loud to check if it sounds natural.</p>
                         </div>
                     </div>
                 </div>

--- a/js/data/config/adminConfig.js
+++ b/js/data/config/adminConfig.js
@@ -91,6 +91,11 @@ export const adminConfig = {
                 enabled: true,
                 visible: true,
                 beta: false
+            },
+            mixlingo: {
+                enabled: true,
+                visible: true,
+                beta: false
             }
         },
         

--- a/js/data/config/constants.js
+++ b/js/data/config/constants.js
@@ -35,7 +35,8 @@ export const STORAGE_KEYS = {
 // Game modes and their identifiers
 export const GAME_MODES = {
     CLASSIC: 'classic',
-    HOLLYBOLLY: 'hollybolly'
+    HOLLYBOLLY: 'hollybolly',
+    MIXLINGO: 'mixlingo'
 };
 
 // Game difficulties

--- a/js/data/config/gameConfig.js
+++ b/js/data/config/gameConfig.js
@@ -57,6 +57,23 @@ export const gameConfig = {
                 maxStreak: 3
             },
             clueTypes: ['place', 'animal', 'thing']
+        },
+
+        mixlingo: {
+            id: 'mixlingo',
+            name: 'MixLingo Mode',
+            description: 'Complete sentences with the correct foreign word',
+            enabled: true,
+            timeLimit: 40,
+            questionsPerRound: 10,
+            maxRounds: 3,
+            scoring: {
+                correct: 10,
+                incorrect: 0,
+                rewardBonus: 0,
+                streakMultiplier: 1.2,
+                maxStreak: 5
+            }
         }
     },
     

--- a/js/data/translations/en.js
+++ b/js/data/translations/en.js
@@ -79,6 +79,8 @@ const englishTranslations = {
     classicDescription: 'Traditional Name-Place-Animal-Thing game',
     hollybollyMode: 'HollyBolly Mode',
     hollybollyDescription: 'Hollywood movies with Bollywood-style clues',
+    mixlingoMode: 'MixLingo Mode',
+    mixlingoDescription: 'Complete sentences with foreign words',
     quickPlay: 'Quick Play',
     customGame: 'Custom Game',
     lastPlayed: 'Continue Last Game',
@@ -87,10 +89,18 @@ const englishTranslations = {
     achievements: 'Achievements'
   },
 
+  // Text for mode tabs
+  gameModes: {
+    classic: 'Classic Mode',
+    hollybolly: 'HollyBolly Mode',
+    mixlingo: 'MixLingo Mode'
+  },
+
   // ===== GAME MODES =====
   gameMode: {
     classic: 'Classic',
     hollybolly: 'HollyBolly',
+    mixlingo: 'MixLingo',
     practice: 'Practice',
     challenge: 'Challenge',
     multiplayer: 'Multiplayer',
@@ -215,6 +225,21 @@ const englishTranslations = {
     hollybollyComplete: 'HollyBolly Game Complete!'
   },
 
+  // ===== MIXLINGO MODE =====
+  mixlingo: {
+    title: 'MixLingo Mode',
+    instructions: 'Complete English sentences using the correct foreign word',
+    startMixlingo: 'Start MixLingo Game',
+    mixlingoComplete: 'MixLingo Game Complete!',
+    objective: '📝 MixLingo Challenge',
+    objectiveText: 'Choose the correct foreign word to complete each sentence.',
+    howItWorks: '🌍 How It Works',
+    howItWorksText: 'One word is replaced with options from your chosen language.',
+    tips: '💡 Tips for Success',
+    tip1: 'Read the whole sentence before selecting.',
+    tip2: 'Say the sentence aloud to check if it flows.'
+  },
+
   // ===== REWARDS SYSTEM =====
   rewards: {
     earned: 'Reward Earned!',
@@ -334,12 +359,16 @@ const englishTranslations = {
     overview: 'Game Overview',
     classicRules: 'Classic Mode Rules',
     hollybollyRules: 'HollyBolly Mode Rules',
+    mixlingoRules: 'MixLingo Mode Rules',
     controls: 'Controls',
     scoring: 'Scoring System',
     tips: 'Tips & Strategies',
     
     classicText: 'In Classic Mode, you\'ll be asked to identify Names, Places, Animals, and Things. Choose the correct answer from the multiple choice options.',
     hollybollyText: 'In HollyBolly Mode, guess Hollywood movies from creative clues involving places, animals, and things. Earn special rewards for consecutive correct answers!',
+    mixlingoText: 'In MixLingo Mode, complete English sentences using the correct foreign word. Build vocabulary by seeing words in context.',
+    'mixlingo.tip1': 'Read the whole sentence before choosing.',
+    'mixlingo.tip2': 'Say the sentence aloud to see if it sounds natural.',
     
     controlsText: 'Use mouse clicks or keyboard navigation. Press Tab to move between options, Enter to select, and Escape to return to menu.',
     

--- a/mixlingo.js
+++ b/mixlingo.js
@@ -1,0 +1,135 @@
+import { mixlingoData } from './mixlingoData.js';
+
+export class MixLingoGame {
+    constructor(gameData = mixlingoData) {
+        this.currentQuestion = null;
+        this.currentDifficulty = 'easy';
+        this.score = 0;
+        this.streak = 0;
+        this.maxStreak = 0;
+        this.questionsAnswered = 0;
+        this.correctAnswers = 0;
+        this.gameData = gameData;
+        this.usedQuestions = new Set();
+    }
+
+    loadGameData(gameData) {
+        this.gameData = gameData;
+        this.usedQuestions.clear();
+        return this.gameData.length > 0;
+    }
+
+    startGame(difficulty = 'easy') {
+        this.currentDifficulty = difficulty;
+        this.score = 0;
+        this.streak = 0;
+        this.questionsAnswered = 0;
+        this.correctAnswers = 0;
+        this.usedQuestions.clear();
+        return this.getNewQuestion();
+    }
+
+    getNewQuestion() {
+        if (this.gameData.length === 0) return null;
+        const available = this.gameData.filter(q => !this.usedQuestions.has(q.id));
+        if (available.length === 0) {
+            this.usedQuestions.clear();
+            return this.getNewQuestion();
+        }
+        const randomIndex = Math.floor(Math.random() * available.length);
+        this.currentQuestion = available[randomIndex];
+        this.usedQuestions.add(this.currentQuestion.id);
+        return this.formatQuestion();
+    }
+
+    formatQuestion() {
+        if (!this.currentQuestion) return null;
+        const q = this.currentQuestion;
+        let answers = [...q.answers];
+        const correct = q.correctAnswer;
+        for (let i = answers.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [answers[i], answers[j]] = [answers[j], answers[i]];
+        }
+        const maxChoices = this.getDifficultyChoices();
+        answers = answers.slice(0, maxChoices);
+        if (!answers.includes(correct)) {
+            answers[Math.floor(Math.random() * answers.length)] = correct;
+        }
+        return {
+            id: q.id,
+            question: q.question,
+            answers,
+            correctAnswer: correct,
+            language: q.language,
+            difficulty: this.currentDifficulty
+        };
+    }
+
+    getDifficultyChoices() {
+        switch (this.currentDifficulty) {
+            case 'easy': return 2;
+            case 'medium': return 3;
+            case 'hard': return 4;
+            default: return 2;
+        }
+    }
+
+    submitAnswer(selected) {
+        if (!this.currentQuestion) return null;
+        const question = this.formatQuestion();
+        const correct = selected === question.correctAnswer;
+        this.questionsAnswered++;
+        if (correct) {
+            this.correctAnswers++;
+            this.streak++;
+            this.maxStreak = Math.max(this.maxStreak, this.streak);
+            this.score += this.getDifficultyPoints();
+        } else {
+            this.streak = 0;
+        }
+        return {
+            correct,
+            correctAnswer: question.correctAnswer,
+            selectedAnswer: selected,
+            streak: this.streak,
+            score: this.score,
+            reward: null,
+            explanation: null
+        };
+    }
+
+    getDifficultyPoints() {
+        switch (this.currentDifficulty) {
+            case 'easy': return 10;
+            case 'medium': return 15;
+            case 'hard': return 25;
+            default: return 10;
+        }
+    }
+
+    getStats() {
+        return {
+            score: this.score,
+            questionsAnswered: this.questionsAnswered,
+            correctAnswers: this.correctAnswers,
+            accuracy: this.questionsAnswered > 0 ? Math.round((this.correctAnswers / this.questionsAnswered) * 100) : 0,
+            currentStreak: this.streak,
+            maxStreak: this.maxStreak,
+            difficulty: this.currentDifficulty
+        };
+    }
+
+    resetGame() {
+        this.currentQuestion = null;
+        this.score = 0;
+        this.streak = 0;
+        this.maxStreak = 0;
+        this.questionsAnswered = 0;
+        this.correctAnswers = 0;
+        this.usedQuestions.clear();
+    }
+}
+
+// default export for compatibility
+export default MixLingoGame;

--- a/mixlingoData.js
+++ b/mixlingoData.js
@@ -1,0 +1,37 @@
+export const mixlingoData = [
+  {
+    id: 1,
+    language: 'fr',
+    question: 'I would like a ____ for breakfast.',
+    answers: ['croissant', 'baguette', 'fromage', 'pain'],
+    correctAnswer: 'croissant'
+  },
+  {
+    id: 2,
+    language: 'es',
+    question: 'We went to the ____ on vacation.',
+    answers: ['playa', 'bosque', 'montana', 'ciudad'],
+    correctAnswer: 'playa'
+  },
+  {
+    id: 3,
+    language: 'de',
+    question: 'My favorite color is ____.',
+    answers: ['blau', 'rot', 'grun', 'gelb'],
+    correctAnswer: 'blau'
+  },
+  {
+    id: 4,
+    language: 'it',
+    question: 'We ate delicious ____ in Rome.',
+    answers: ['pizza', 'pasta', 'gelato', 'risotto'],
+    correctAnswer: 'gelato'
+  },
+  {
+    id: 5,
+    language: 'pt',
+    question: 'He said "good morning" - ____.',
+    answers: ['bom dia', 'ola', 'tchau', 'obrigado'],
+    correctAnswer: 'bom dia'
+  }
+];


### PR DESCRIPTION
## Summary
- introduce MixLingo game mode and data
- register MixLingo in app configs and translations
- update home and instructions screens with MixLingo options
- allow GameUI to select between HollyBolly and MixLingo

## Testing
- `npx eslint js/**/*.js mixlingo.js GameUI.js hollybolly.js` *(fails: module is not defined)*
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_6843418b8a38832bb0bc8d0d931ccf73