### PR TITLE
Fix classic game start

### DIFF
--- a/js/modules/game/gameStateManager.js
+++ b/js/modules/game/gameStateManager.js
@@ -38,6 +38,16 @@ class GameStateManager {
             this.gameState.questions = questions;
         }
     }
+
+    saveCurrentState() {
+        try {
+            if (this.gameState && typeof localStorage !== 'undefined') {
+                localStorage.setItem('lingoquest_gameState', JSON.stringify(this.gameState));
+            }
+        } catch (e) {
+            console.warn('Failed to save game state', e);
+        }
+    }
 }
 
 export default GameStateManager;


### PR DESCRIPTION
## Summary
- wire up MCQ generator in main app
- implement `startGame()` workflow
- ensure game screen navigation works
- persist game state on unload

## Testing
- `npm run lint` *(fails: module is not defined)*
- `npm test` *(fails: needs jest installation)*

------
https://chatgpt.com/codex/tasks/task_e_68435547e848832b852db1f619dc3811