### PR TITLE
Fix ComponentLoader init

### DIFF
--- a/js/modules/core/componentLoader.js
+++ b/js/modules/core/componentLoader.js
@@ -3,6 +3,14 @@ class ComponentLoader {
     constructor() {
         this.loadedComponents = new Map();
         this.componentCache = new Map();
+        this.isInitialized = false;
+    }
+
+    async init() {
+        console.log('📦 ComponentLoader initializing...');
+        await this.loadAllComponents();
+        this.isInitialized = true;
+        console.log('✅ ComponentLoader initialized');
     }
 
     async loadComponent(componentName, containerId) {


### PR DESCRIPTION
## Summary
- implement missing init method in ComponentLoader

## Testing
- `npm test` *(fails: needs interactive package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6843612374b4832b91368c8f1b55d044