### PR TITLE
Add tools screen direct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# lingoq
+# LingoQuest
+
+This repository contains the source code for the LingoQuest web app.
+
+## Direct Tools Link
+
+You can open the tools screen directly with the following URL:
+
+https://alliebaig.github.io/lingoq/index.html?tools

--- a/js/main.js
+++ b/js/main.js
@@ -610,6 +610,17 @@ class LingoQuestApp {
 // Global app instance
 let app = null;
 
+// Handle direct links such as ?tools
+function handleDirectLinks() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('tools')) {
+        const uiManager = app?.getModule('uiManager');
+        if (uiManager) {
+            uiManager.showScreen('tools-screen');
+        }
+    }
+}
+
 // Initialize app when DOM is ready
 document.addEventListener('DOMContentLoaded', async () => {
     try {
@@ -626,7 +637,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             getReport: () => app.getInitializationReport(),
             restart: () => app.restart()
         };
-        
+
+        // Show screen based on query parameters
+        handleDirectLinks();
+
     } catch (error) {
         console.error('💥 Failed to initialize LingoQuest:', error);
         


### PR DESCRIPTION
## Summary
- document how to open the tools screen directly
- support `?tools` query parameter to load the tools screen on startup

## Testing
- `npm test` *(fails: needs jest install)*

------
https://chatgpt.com/codex/tasks/task_e_6844058adef0832bb3245cd6ee8a4155