### PR TITLE
Handle unregister service worker feedback

### DIFF
--- a/js/modules/core/eventManager.js
+++ b/js/modules/core/eventManager.js
@@ -118,10 +118,21 @@ class EventManager {
         const performReset = async () => {
             if ('serviceWorker' in navigator) {
                 const registrations = await navigator.serviceWorker.getRegistrations();
+                let unregistered = false;
                 for (const reg of registrations) {
-                    await reg.unregister();
+                    try {
+                        unregistered = (await reg.unregister()) || unregistered;
+                    } catch (err) {
+                        console.warn('Failed to unregister service worker', err);
+                    }
                 }
-                this.app.getUIManager().showToast('Service worker reset', 'success');
+
+                if (unregistered) {
+                    this.app.getUIManager().showToast('Service worker unregistered', 'success');
+                } else {
+                    this.app.getUIManager().showToast('No service worker to unregister', 'info');
+                }
+
                 setTimeout(() => location.reload(true), 500);
             }
         };


### PR DESCRIPTION
## Summary
- improve feedback when resetting service worker

## Testing
- `npm test` *(fails: needs jest installation)*

------
https://chatgpt.com/codex/tasks/task_e_68440ae91ec8832bbb7588f9e81f71eb