### PR TITLE
Fix service worker asset path

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -17,7 +17,8 @@ const STATIC_ASSETS = [
   '/css/components.css',
   '/css/responsive.css',
   '/css/animations.css',
-  '/css/accessibility.css',
+  // Corrected path for accessibility styles
+  '/css/modules/accessibility.css',
   
   // JavaScript Core Files
   '/js/main.js',


### PR DESCRIPTION
## Summary
- fix service worker asset reference to accessibility.css

## Testing
- `npx --yes jest tests/unit/helpers.test.js --runInBand --verbose` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68441cf336a0832b97612560717ef70d