### PR TITLE
Fix truncation in SettingsManager

### DIFF
--- a/js/modules/settings/settingsManager.js
+++ b/js/modules/settings/settingsManager.js
@@ -608,4 +608,7 @@ class SettingsManager {
     }
 
 
+}
+
+export default SettingsManager;
 


### PR DESCRIPTION
## Summary
- fix truncated file by closing the class and exporting it

## Testing
- `node --check js/modules/settings/settingsManager.js`
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68441f86ddc4832b9d72b34a0c21a018