### PR TITLE
Fix missing event emitter method

### DIFF
--- a/js/modules/settings/settingsManager.js
+++ b/js/modules/settings/settingsManager.js
@@ -61,6 +61,14 @@ class SettingsManager {
         this.settingsLoaded = false;
     }
 
+    emitEvent(event, data = {}) {
+        if (this.eventManager && typeof this.eventManager.emit === 'function') {
+            this.eventManager.emit(event, data);
+        } else {
+            console.warn('EventManager not available to emit event:', event);
+        }
+    }
+
     async init() {
         console.log('⚙️ SettingsManager initializing...');
         


### PR DESCRIPTION
## Summary
- implement `emitEvent` helper in SettingsManager

## Testing
- `npm test` *(fails: Can't find jest config)*

------
https://chatgpt.com/codex/tasks/task_e_68442906aaa4832bb11c1a9061f7ec3d