### PR TITLE
Fix classic mode UI

### DIFF
--- a/js/modules/core/eventManager.js
+++ b/js/modules/core/eventManager.js
@@ -66,8 +66,23 @@ class EventManager {
     }
 
     setupGameScreenEvents() {
-        // Basic game events - will be expanded later
         document.addEventListener('click', (e) => {
+            const choice = e.target.closest('.choice-option');
+            if (choice) {
+                const gameLogic = this.app.getModule('gameLogic');
+                if (gameLogic) {
+                    gameLogic.selectChoice(choice);
+                }
+            }
+
+            if (e.target.closest('#confirm-answer')) {
+                const gameLogic = this.app.getModule('gameLogic');
+                const gameStateManager = this.app.getModule('gameStateManager');
+                if (gameLogic && gameStateManager) {
+                    gameLogic.confirmAnswer(gameStateManager.getGameState());
+                }
+            }
+
             if (e.target.closest('#quit-game')) {
                 if (confirm('Are you sure you want to quit?')) {
                     this.app.getUIManager().showScreen('home-screen');

--- a/js/modules/game/gameLogic.js
+++ b/js/modules/game/gameLogic.js
@@ -70,6 +70,34 @@ class GameLogic {
         });
     }
 
+    confirmAnswer(gameState) {
+        const selected = document.querySelector('.choice-option.selected');
+        if (!selected) return;
+
+        const choiceIndex = parseInt(selected.dataset.choiceIndex, 10);
+        const question = gameState.questions[gameState.currentQuestion - 1];
+        const choice = question.choices[choiceIndex];
+        const isCorrect = choice.correct;
+
+        if (isCorrect) {
+            selected.classList.add('correct');
+            gameState.correctAnswers++;
+            gameState.streak++;
+            gameState.bestStreak = Math.max(gameState.bestStreak, gameState.streak);
+        } else {
+            selected.classList.add('incorrect');
+            gameState.incorrectAnswers++;
+            gameState.streak = 0;
+        }
+
+        this.disableChoices();
+        this.updateStreakDisplay(gameState);
+
+        setTimeout(() => {
+            this.loadNextQuestion(gameState);
+        }, 800);
+    }
+
     selectChoice(choiceElement) {
         document.querySelectorAll('.choice-option').forEach(el => {
             el.classList.remove('selected');


### PR DESCRIPTION
## Summary
- wire up classic game screen events
- handle answer confirmation in game logic

## Testing
- `npm test` *(fails: needs jest installation)*

------
https://chatgpt.com/codex/tasks/task_e_68445a513628832b97abee99efbd6cf4