### PR TITLE
Fix theme initialization

### DIFF
--- a/js/modules/settings/themeManager.js
+++ b/js/modules/settings/themeManager.js
@@ -149,15 +149,20 @@ class ThemeManager {
     getAvailableThemes() {
         return this.themes;
     }
-    
+
     getThemesByCategory(category) {
         return this.themeCategories[category] || [];
     }
-    
+
     getCurrentTheme() {
         return this.currentTheme;
     }
-    
+
+    // Re-apply the currently selected theme
+    async applyCurrentTheme() {
+        await this.setTheme(this.currentTheme);
+    }
+
     isStudentTheme(themeName) {
         return this.studentThemes.includes(themeName);
     }


### PR DESCRIPTION
## Summary
- add `applyCurrentTheme` method to ThemeManager so that main.js can call it

## Testing
- `npm test` *(fails: jest package missing)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_68446f7297b4832b87a6569c097f0ba9