### PR TITLE
Provide enTranslations alias for compatibility

### DIFF
--- a/js/data/translations/en.js
+++ b/js/data/translations/en.js
@@ -449,6 +449,7 @@ const englishTranslations = {
 // Export the translations object
 export default englishTranslations;
 
-// Also export as named export for compatibility
-export { englishTranslations };
+// Provide aliases for backward compatibility
+const enTranslations = englishTranslations;
+export { englishTranslations, enTranslations };
 


### PR DESCRIPTION
## Summary
- export `enTranslations` alias in English translations

## Testing
- `npm run lint` *(fails: A config object is using the "root" key)*
- `npm test` *(failed to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68447811ed20832bb2cd2f281e92cb9d