### PR TITLE
Fix duplicate variable declaration in main.js

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -106,9 +106,8 @@ class LingoQuestApp {
             this.logStep(`Initialization completed in ${initTime}ms`);
             
             // Trigger app ready event
-            const eventManager = this.modules.get('eventManager');
             if (eventManager) {
-                eventManager.emit('app:ready', { 
+                eventManager.emit('app:ready', {
                     initTime,
                     steps: this.initializationSteps
                 });


### PR DESCRIPTION
## Summary
- remove duplicate `eventManager` declaration in `init`

## Testing
- `npm test` *(fails: ReferenceError `module is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_68447a9846e0832b94d2a1389b6f9dd3