### PR TITLE
Fix home screen layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -168,6 +168,52 @@ button {
   height: 24px;
 }
 
+/* ========== Home Screen Game Modes ========== */
+.game-mode-selector {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+  background: var(--bg-tertiary, #f5f5f5);
+  border-radius: 8px;
+  padding: 0.25rem;
+  gap: 0.25rem;
+}
+
+.mode-tab {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-secondary, #666);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+  text-align: center;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mode-tab.active {
+  background: var(--bg-primary, #fff);
+  color: var(--primary-color, #333);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.game-modes {
+  display: none;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.game-modes.active {
+  display: grid;
+}
+
 /* ========== Utility Fixes ========== */
 .hidden {
   display: none !important;


### PR DESCRIPTION
## Summary
- hide inactive game modes on the home screen

## Testing
- `npm run lint` *(fails: A config object is using the "root" key)*
- `npm run lint:css` *(interactive install prompt prevented execution)*
- `npm test` *(interactive install prompt prevented execution)*

------
https://chatgpt.com/codex/tasks/task_e_6844b1996068832bbea8348c12293710