### PR TITLE
Fix dropdown styling in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/css/components.css
+++ b/css/components.css
@@ -254,12 +254,31 @@
 }
 
 .select-input {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  padding: var(--spacing-md);
+  border: 2px solid var(--border-color);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-base);
+  background: var(--input-background);
+  color: var(--text-primary);
+  transition: all var(--transition-fast);
+  box-sizing: border-box;
+  cursor: pointer;
+
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
   background-position: right 12px center;
   background-repeat: no-repeat;
   background-size: 16px;
   padding-right: 40px;
   appearance: none;
+}
+
+.select-input:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px var(--primary-light);
+  outline: none;
 }
 
 /* Toggle Switch */


### PR DESCRIPTION
## Summary
- style `select-input` to inherit common input styles and respect theme colors
- ignore development artifacts

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6844b72fc8bc832ba8650f949c182a2a