### PR TITLE
Add main menu navigation option

### DIFF
--- a/components/game-screen.html
+++ b/components/game-screen.html
@@ -149,6 +149,9 @@
             <button id="pause-game" class="btn btn-outline">
                 <span data-i18n="buttons.pause">Pause</span>
             </button>
+            <button id="main-menu" class="btn btn-secondary">
+                <span data-i18n="buttons.mainMenu">Main Menu</span>
+            </button>
             <button id="quit-game" class="btn btn-outline btn-danger">
                 <span data-i18n="buttons.quit">Quit Game</span>
             </button>

--- a/js/data/translations/de.js
+++ b/js/data/translations/de.js
@@ -491,6 +491,7 @@ export const deTranslations = {
         pause: 'Pausieren',
         resume: 'Fortsetzen',
         quit: 'Beenden',
+        mainMenu: 'Hauptmenü',
         confirm: 'Bestätigen',
         cancel: 'Abbrechen',
         continue: 'Weiter',

--- a/js/data/translations/en.js
+++ b/js/data/translations/en.js
@@ -57,6 +57,7 @@ const englishTranslations = {
     continue: 'Continue Game',
     pause: 'Pause',
     quit: 'Quit Game',
+    mainMenu: 'Main Menu',
     viewDetails: 'View Detailed Results',
     playAgain: 'Play Again',
     tryDifferentMode: 'Try Different Mode',

--- a/js/data/translations/fr.js
+++ b/js/data/translations/fr.js
@@ -54,6 +54,7 @@ export const frTranslations = {
         continue: 'Continuer le jeu',
         pause: 'Pause',
         quit: 'Quitter le jeu',
+        mainMenu: 'Menu Principal',
         viewDetails: 'Voir les résultats détaillés',
         playAgain: 'Rejouer',
         tryDifferentMode: 'Essayer un autre mode',

--- a/js/modules/core/eventManager.js
+++ b/js/modules/core/eventManager.js
@@ -91,6 +91,10 @@ class EventManager {
                     this.app.getUIManager().showScreen('home-screen');
                 }
             }
+
+            if (e.target.closest('#main-menu')) {
+                this.app.getUIManager().showScreen('home-screen');
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- show a **Main Menu** button during gameplay
- return to home screen when the new button is used
- support new button text in English, French and German translations

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68454648d19c832b8fd141e078e0430b