### PR TITLE
Add language dropdown for MCQ answers

### DIFF
--- a/GameUI.js
+++ b/GameUI.js
@@ -28,7 +28,7 @@ export class GameUI {
             streak: document.getElementById('streak'),
             accuracy: document.getElementById('accuracy'),
             difficultyBtns: document.querySelectorAll('.difficulty-btn'),
-            languageSelect: document.getElementById('language-select')
+            languageSelect: document.getElementById('answer-language-select')
         };
     }
 

--- a/components/game-screen.html
+++ b/components/game-screen.html
@@ -21,6 +21,16 @@
                         <div id="progress-fill" class="progress-fill" style="width: 5%"></div>
                     </div>
                 </div>
+
+                <!-- Answer language selection -->
+                <div class="answer-language">
+                    <label for="answer-language-select">Answers in Language:</label>
+                    <select id="answer-language-select" class="select-input">
+                        <option value="en">English</option>
+                        <option value="fr">Français</option>
+                        <option value="de">Deutsch</option>
+                    </select>
+                </div>
             </div>
 
             <!-- Streak Counter for HollyBolly Mode -->

--- a/js/GameUI.js
+++ b/js/GameUI.js
@@ -28,7 +28,7 @@ export class GameUI {
             streak: document.getElementById('streak'),
             accuracy: document.getElementById('accuracy'),
             difficultyBtns: document.querySelectorAll('.difficulty-btn'),
-            languageSelect: document.getElementById('language-select')
+            languageSelect: document.getElementById('answer-language-select')
         };
     }
 


### PR DESCRIPTION
## Summary
- add an answer language selector on the game screen
- wire GameUI to use the new selector for showing MCQ answers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845573180a8832ba9b600a561a99e2e