### PR TITLE
Fix dropdown layout and color

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -254,8 +254,9 @@
 }
 
 .select-input {
-  display: block;
-  width: 100%;
+  display: inline-block;
+  width: auto;
+  min-width: 120px;
   max-width: 100%;
   padding: var(--spacing-md);
   border: 2px solid var(--border-color);

--- a/css/themes.css
+++ b/css/themes.css
@@ -28,7 +28,7 @@
   --text-accent: #1976d2;
   --text-muted: #9e9e9e;
   --border-color: #e0e0e0;
-  --input-background: #ffffff;
+  --input-background: var(--surface-color);
   --hover-background: #f8f9fa;
   --shadow-color: rgba(0, 0, 0, 0.1);
   --border-radius: 8px;
@@ -66,7 +66,7 @@ html, body {
   --text-accent: #1976d2;
   --text-muted: #9e9e9e;
   --border-color: #e0e0e0;
-  --input-background: #ffffff;
+  --input-background: var(--surface-color);
   --hover-background: #f8f9fa;
   --shadow-color: rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
## Summary
- tweak `.select-input` so it doesn't stretch across the page
- use surface color for light theme input backgrounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456254933c832b865ca261c27512b0