### PR TITLE
Adjust home screen layout

### DIFF
--- a/components/home-screen.html
+++ b/components/home-screen.html
@@ -22,20 +22,20 @@
         </div>
     </div>
 
-        <!-- Difficulty Selector -->
-        <div class="difficulty-selector" style="margin: 1rem 0;">
-            <label for="difficulty-select" data-i18n="settings.difficulty" style="margin-right:0.5rem;">Difficulty:</label>
-            <select id="difficulty-select" class="select-input">
-                <option value="easy" data-i18n="modes.easy.title">Easy</option>
-                <option value="medium" data-i18n="modes.medium.title">Medium</option>
-                <option value="hard" data-i18n="modes.hard.title">Hard</option>
-            </select>
-        </div>
+        <!-- Option Selectors (Difficulty & Theme) -->
+        <div class="option-selectors">
+            <div class="difficulty-selector">
+                <label for="difficulty-select" data-i18n="settings.difficulty" style="margin-right:0.5rem;">Difficulty:</label>
+                <select id="difficulty-select" class="select-input">
+                    <option value="easy" data-i18n="modes.easy.title">Easy</option>
+                    <option value="medium" data-i18n="modes.medium.title">Medium</option>
+                    <option value="hard" data-i18n="modes.hard.title">Hard</option>
+                </select>
+            </div>
 
-        <!-- Theme Selector -->
-        <div class="theme-selector" style="margin: 1rem 0;">
-            <label for="home-theme-select" data-i18n="settings.theme" style="margin-right:0.5rem;">Theme:</label>
-            <select id="home-theme-select" class="select-input">
+            <div class="theme-selector">
+                <label for="home-theme-select" data-i18n="settings.theme" style="margin-right:0.5rem;">Theme:</label>
+                <select id="home-theme-select" class="select-input">
                 <!-- Senior-Friendly Themes -->
                 <optgroup label="Senior Friendly">
                     <option value="light" data-i18n="themes.light">Light</option>
@@ -59,7 +59,8 @@
                 <optgroup label="Cartoon Themes">
                     <option value="jetsons" data-i18n="themes.jetsons">🤖 Jetsons</option>
                 </optgroup>
-            </select>
+                </select>
+            </div>
         </div>
 
         <!-- Classic Game Modes -->

--- a/css/modules/components.css
+++ b/css/modules/components.css
@@ -311,6 +311,15 @@
   margin-top: 2rem;
 }
 
+/* ===== HOME SCREEN SELECTOR ROW ===== */
+.option-selectors {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+}
+
 /* ===== COMPONENT OVERFLOW FIXES ===== */
 .card,
 .button,


### PR DESCRIPTION
## Summary
- organize difficulty and theme selectors together above the game modes
- keep start button section after the game modes
- style the new selector row

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456f93dc38832bbd43d6f945a99775