### PR TITLE
Add font dropdown in main menu

### DIFF
--- a/components/home-screen.html
+++ b/components/home-screen.html
@@ -22,7 +22,7 @@
         </div>
     </div>
 
-        <!-- Option Selectors (Difficulty & Theme) -->
+        <!-- Option Selectors (Difficulty, Theme & Font) -->
         <div class="option-selectors">
             <div class="difficulty-selector">
                 <label for="difficulty-select" data-i18n="settings.difficulty" style="margin-right:0.5rem;">Difficulty:</label>
@@ -66,6 +66,17 @@
                 <optgroup label="Cartoon Themes">
                     <option value="jetsons" data-i18n="themes.jetsons">🤖 Jetsons</option>
                 </optgroup>
+                </select>
+            </div>
+
+            <div class="font-selector">
+                <label for="home-font-select" data-i18n="settings.fontFamily" style="margin-right:0.5rem;">Font:</label>
+                <select id="home-font-select" class="select-input">
+                    <option value="system" data-i18n="fonts.system">System Default</option>
+                    <option value="serif" data-i18n="fonts.serif">Serif (Times)</option>
+                    <option value="sans-serif" data-i18n="fonts.sansSerif">Sans Serif (Arial)</option>
+                    <option value="monospace" data-i18n="fonts.monospace">Monospace (Courier)</option>
+                    <option value="dyslexic" data-i18n="fonts.dyslexic">Dyslexic Friendly</option>
                 </select>
             </div>
         </div>

--- a/js/modules/core/eventManager.js
+++ b/js/modules/core/eventManager.js
@@ -121,6 +121,11 @@ class EventManager {
                 this.app.getThemeManager().setTheme(theme);
                 this.app.getSettingsManager().setSetting('theme', theme);
             }
+
+            if (e.target.matches('#font-family-select, #home-font-select')) {
+                const family = e.target.value;
+                this.app.getSettingsManager().setSetting('fontFamily', family);
+            }
         });
     }
 
@@ -171,6 +176,16 @@ class EventManager {
             if (settingsSelect) settingsSelect.value = theme;
             if (homeSelect) homeSelect.value = theme;
             this.app.getUIManager().showToast(`Theme changed to ${name}`, 'success');
+        });
+
+        // Keep font selectors in sync
+        window.addEventListener('fontFamilyChanged', (e) => {
+            const family = e.detail.fontFamily;
+            const settingsSelect = document.getElementById('font-family-select');
+            const homeSelect = document.getElementById('home-font-select');
+            if (settingsSelect) settingsSelect.value = family;
+            if (homeSelect) homeSelect.value = family;
+            this.app.getUIManager().showToast(`Font changed to ${family}`, 'success');
         });
     }
 

--- a/js/modules/settings/settingsManager.js
+++ b/js/modules/settings/settingsManager.js
@@ -394,9 +394,13 @@ class SettingsManager {
             monospace: '"SF Mono", "Monaco", "Inconsolata", "Roboto Mono", monospace',
             dyslexic: '"OpenDyslexic", "Comic Sans MS", cursive, sans-serif'
         };
-        
+
         const fontFamily = familyMap[family] || familyMap.system;
         root.style.setProperty('--font-family-base', fontFamily);
+
+        window.dispatchEvent(new CustomEvent('fontFamilyChanged', {
+            detail: { fontFamily: family }
+        }));
     }
 
     applyButtonSize(size) {


### PR DESCRIPTION
## Summary
- allow selecting font directly from the home screen
- sync new font dropdown with settings via EventManager
- dispatch a `fontFamilyChanged` event when font changes

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68458a5c378c832bbb4626bde051ca24