### PR TITLE
Fix answer language sync

### DIFF
--- a/GameUI.js
+++ b/GameUI.js
@@ -98,6 +98,19 @@ export class GameUI {
                     this.displayQuestion();
                 }
             });
+
+            // Sync with global language changes
+            document.addEventListener('language:changed', (e) => {
+                const lang = e.detail.currentLanguage;
+                if (lang && this.elements.languageSelect.value !== lang) {
+                    this.elements.languageSelect.value = lang;
+                }
+                this.game.setLanguage(lang);
+                if (this.currentQuestion) {
+                    this.currentQuestion = this.game.formatQuestion();
+                    this.displayQuestion();
+                }
+            });
         }
     }
 

--- a/js/GameUI.js
+++ b/js/GameUI.js
@@ -104,6 +104,19 @@ export class GameUI {
                     this.displayQuestion();
                 }
             });
+
+            // Sync with global language changes
+            document.addEventListener('language:changed', (e) => {
+                const lang = e.detail.currentLanguage;
+                if (lang && this.elements.languageSelect.value !== lang) {
+                    this.elements.languageSelect.value = lang;
+                }
+                this.game.setLanguage(lang);
+                if (this.currentQuestion) {
+                    this.currentQuestion = this.game.formatQuestion();
+                    this.displayQuestion();
+                }
+            });
         }
     }
 

--- a/js/modules/settings/languageManager.js
+++ b/js/modules/settings/languageManager.js
@@ -107,6 +107,16 @@ export class LanguageManager {
                 currentLanguage: this.currentLanguage,
                 translations: this.translator.getCurrentTranslations()
             });
+
+            // Also dispatch DOM event for modules not using EventManager
+            document.dispatchEvent(
+                new CustomEvent('language:changed', {
+                    detail: {
+                        previousLanguage,
+                        currentLanguage: this.currentLanguage
+                    }
+                })
+            );
             
             console.log(`✅ Language changed to: ${languageCode}`);
             return true;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run lint && npm run test",
 
 
-    "lint": "eslint js/ --no-warn-ignored"
+    "lint": "eslint js/ --no-warn-ignored",
     "_lint_comment": "eslint js/**/*.js",
     "_lint_comment": "npx eslint --config .eslintrc.cjs js/**/*.js --fix",
 


### PR DESCRIPTION
## Summary
- dispatch DOM `language:changed` events from `LanguageManager`
- listen for `language:changed` in `GameUI` to update current question language
- same update for alternate `GameUI.js`
- fix missing comma in `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458d9f3b08832b8fc8b22b7fcefaae