### PR TITLE
Add visible error log

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -727,9 +727,30 @@
     margin: var(--spacing-md);
   }
   
-  .card {
+
+.card {
     padding: var(--spacing-md);
   }
+}
+
+/* Error Log Component */
+.error-log {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-height: 150px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: var(--spacing-sm);
+  z-index: 10000;
+  font-family: var(--font-family-mono, monospace);
+}
+
+.error-log .error-entry {
+  margin-bottom: var(--spacing-xs);
 }
 
 /* High Contrast Component Overrides */

--- a/index.html
+++ b/index.html
@@ -50,8 +50,9 @@
             <div id="tools-screen-container"></div>
         </main>
 
-        <div id="loading-overlay-container"></div>
+    <div id="loading-overlay-container"></div>
     <div id="toast-container-element"></div>
+    <div id="error-log" class="error-log"></div>
     <div class="reset-links">
         <a href="#" id="reset-service-worker">Reset Service Worker</a>
         |

--- a/js/main.js
+++ b/js/main.js
@@ -39,6 +39,9 @@ import GameStateManager from './modules/game/gameStateManager.js';
 import ScoreCalculator from './modules/game/scoreCalculator.js';
 import MCQGenerator from './modules/game/mcqGenerator.js';
 import helpers from './modules/utils/helpers.js';
+import errorLogger from './modules/utils/errorLogger.js';
+// Initialize error logger for UI visibility
+void errorLogger;
 
 
 

--- a/js/modules/utils/errorLogger.js
+++ b/js/modules/utils/errorLogger.js
@@ -1,0 +1,50 @@
+/**
+ * Purpose: Display runtime errors in a persistent on-screen log.
+ * Key features: console.error interception, DOM log display.
+ * MIT License: https://github.com/AllieBaig/LingoQuest/blob/main/LICENSE
+ */
+
+class ErrorLogger {
+    constructor() {
+        this.originalConsoleError = console.error.bind(console);
+        this.container = null;
+        document.addEventListener('DOMContentLoaded', () => this.init());
+    }
+
+    init() {
+        this.container = document.getElementById('error-log');
+        if (!this.container) return;
+
+        console.error = (...args) => {
+            this.log(...args);
+            this.originalConsoleError(...args);
+        };
+    }
+
+    log(...args) {
+        if (!this.container) return;
+        const message = args
+            .map(arg => {
+                if (arg instanceof Error) {
+                    return arg.stack || arg.message;
+                }
+                if (typeof arg === 'object') {
+                    try {
+                        return JSON.stringify(arg);
+                    } catch {
+                        return String(arg);
+                    }
+                }
+                return String(arg);
+            })
+            .join(' ');
+
+        const entry = document.createElement('div');
+        entry.className = 'error-entry';
+        entry.textContent = message;
+        this.container.appendChild(entry);
+    }
+}
+
+const errorLogger = new ErrorLogger();
+export default errorLogger;


### PR DESCRIPTION
## Summary
- add error log area in `index.html`
- show error log entries with new `errorLogger` module
- load error logger at startup in `main.js`
- style the error log component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a0105f20832b9d60f60368cab0c5