### PR TITLE
Fix language preference save on missing storage manager

### DIFF
--- a/js/modules/settings/languageManager.js
+++ b/js/modules/settings/languageManager.js
@@ -98,7 +98,16 @@ export class LanguageManager {
             
             // Save preference if requested
             if (savePreference) {
-                this.storageManager.setItem(STORAGE_KEYS.LANGUAGE_PREFERENCE, languageCode);
+                if (this.storageManager && typeof this.storageManager.setItem === 'function') {
+                    this.storageManager.setItem(
+                        STORAGE_KEYS.LANGUAGE_PREFERENCE,
+                        languageCode
+                    );
+                } else {
+                    console.warn(
+                        '⚠️ StorageManager unavailable, language preference not saved'
+                    );
+                }
             }
             
             // Emit language change event


### PR DESCRIPTION
## Summary
- handle missing storageManager when saving language preference

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845d435cfc4832b85e2827981d43587