### PR TITLE
Fix invisible dropdown text

### DIFF
--- a/js/modules/settings/themeManager.js
+++ b/js/modules/settings/themeManager.js
@@ -261,10 +261,20 @@ class ThemeManager {
 
     updateDropdownTextColor() {
         const root = document.documentElement;
-        const primary = getComputedStyle(root).getPropertyValue('--primary-color').trim();
-        if (!primary) return;
+        const background = getComputedStyle(root)
+            .getPropertyValue('--input-background')
+            .trim();
+        if (!background) return;
 
-        const contrast = ThemeManager.getOppositeColor(primary);
+        let contrast = ThemeManager.getOppositeColor(background);
+
+        // Fallback to text-primary if contrast matches background
+        if (contrast.toLowerCase() === background.toLowerCase()) {
+            contrast = getComputedStyle(root)
+                .getPropertyValue('--text-primary')
+                .trim();
+        }
+
         root.style.setProperty('--dropdown-text-color', contrast);
         document.querySelectorAll('select').forEach(el => {
             el.style.color = contrast;


### PR DESCRIPTION
## Summary
- compute dropdown text color using input background for proper contrast

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845f235e3d0832bab59a513f41e2a56