### PR TITLE
Fix dropdown text color

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -192,7 +192,8 @@
 .card-title {
   font-size: var(--font-size-xl);
   font-weight: 600;
-  color: var(--text-primary);
+  /* Use dropdown text variable for better contrast */
+  color: var(--dropdown-text-color, var(--text-primary));
   margin: 0;
 }
 
@@ -224,7 +225,8 @@
   display: block;
   font-size: var(--font-size-base);
   font-weight: 600;
-  color: var(--text-primary);
+  /* Use dropdown text variable for better contrast */
+  color: var(--dropdown-text-color, var(--text-primary));
   margin-bottom: var(--spacing-sm);
 }
 
@@ -263,7 +265,8 @@
   border-radius: var(--border-radius);
   font-size: var(--font-size-base);
   background: var(--input-background);
-  color: var(--text-primary);
+  /* Use dropdown text variable for better contrast */
+  color: var(--dropdown-text-color, var(--text-primary));
   transition: all var(--transition-fast);
   box-sizing: border-box;
   cursor: pointer;

--- a/css/modules/components.css
+++ b/css/modules/components.css
@@ -194,7 +194,8 @@
   border-radius: var(--border-radius, 8px);
   font-size: var(--font-size-base, 1rem);
   background: var(--input-background, #ffffff);
-  color: var(--text-primary, #212121);
+  /* Use dropdown text variable for better contrast */
+  color: var(--dropdown-text-color, var(--text-primary, #212121));
   transition: all var(--transition-base, 0.3s ease);
   box-sizing: border-box;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- improve dropdown select color variable
- ensure select inputs use the contrast variable

## Testing
- `npm test`
- `npm run lint:css` *(fails: needs network)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc629900832bb190ca2b15c3295e