### PR TITLE
Fix dropdowns missing in home screen

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -683,13 +683,19 @@ function handleDirectLinks() {
 document.addEventListener('DOMContentLoaded', async () => {
     helpers.dom.setViewportHeightVar();
     window.addEventListener('resize', helpers.dom.setViewportHeightVar);
+
+    // Enhance dropdowns once components have loaded
+    document.addEventListener('allComponentsLoaded', () => {
+        CustomDropdown.enhanceAll();
+    });
+
     try {
         app = new LingoQuestApp();
         await app.init();
-        
+
         // Make app globally accessible for debugging
         window.LingoQuest = app;
-        
+
         // Add debug helpers
         window.LingoQuest.debug = {
             getModules: () => Array.from(app.modules.keys()),


### PR DESCRIPTION
## Summary
- reinitialize custom dropdowns after component load

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846ead612e8832bba924c84c8d325bd